### PR TITLE
Support `linux/arm64` images for server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,24 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: 'devcontainers' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'devcontainers'
+    directory: '/'
     schedule:
       interval: 'monthly'
       time: '02:00'
-    open-pull-requests-limit: 10
 
-  - package-ecosystem: 'github-actions' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
       interval: 'monthly'
       time: '02:00'
-    open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns: ['docker/*']
 
   - package-ecosystem: 'dotnet-sdk'
     directory: '/'
@@ -45,7 +46,7 @@ updates:
       command-line:
         patterns: ['System.CommandLine*']
       event-bus:
-        patterns: ['Tingle.EventBus.*']
+        patterns: ['Tingle.EventBus*']
       microsoft:
         patterns: ['Microsoft.*']
         exclude-patterns:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,14 @@ env:
   GITHUB_SHA: ${{ github.sha }} # not discovered by default
   GITHUB_REF_NAME: ${{ github.ref_name }} # not discovered by default
 
+  DOCKER_TAGS: '' # helps with intellisense
+
 jobs:
   Build:
     runs-on: ubuntu-latest
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       IMAGE_NAME: 'azure-resources-cleaner'
-      DOCKER_BUILDKIT: 1 # Enable Docker BuildKit
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -144,43 +145,74 @@ jobs:
       run: docker pull "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
       continue-on-error: true
 
-    - name: Build image
-      run: |
-        docker build \
-        -f Tingle.AzureCleaner/Dockerfile \
-        --label com.github.image.run.id=${{ github.run_id }} \
-        --label com.github.image.run.number=${{ github.run_number }} \
-        --label com.github.image.job.id=${{ github.job }} \
-        --label com.github.image.source.sha=${{ github.sha }} \
-        --label com.github.image.source.branch=${{ github.ref }} \
-        -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest" \
-        -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.shortSha }}" \
-        -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.fullSemVer }}" \
-        -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major}}.${{ steps.gitversion.outputs.minor }}" \
-        -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major }}" \
-        --cache-from ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest \
-        --build-arg BUILDKIT_INLINE_CACHE=1 \
-        .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    # Generate tags to use in multi-arch build.
+    # This is because we cannot build multi-arch images and load them for later pushing.
+    # Different tags are pushed depending on the current ref.
+    - name: Compute Docker tags
+      id: docker-tags-generator
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { ref } = context;
+          const { owner: repoOwner } = context.repo;
+          const {
+            IMAGE_NAME: imageName,
+            SHORT_SHA: shortSha,
+            FULL_SEMVER: fullSemVer,
+            MAJOR: major,
+            MINOR: minor,
+          } = process.env;
+
+          let tags = [`ghcr.io/${repoOwner}/${imageName}:${fullSemVer}`];
+          if (ref === 'refs/heads/main' || ref.startsWith('refs/tags/')) {
+            tags.push(`ghcr.io/${repoOwner}/${imageName}:latest`);
+            tags.push(`ghcr.io/${repoOwner}/${imageName}:${shortSha}`);
+          }
+          if (ref.startsWith('refs/tags/')) {
+            tags.push(`ghcr.io/${repoOwner}/${imageName}:${major}.${minor}`);
+            tags.push(`ghcr.io/${repoOwner}/${imageName}:${major}`);
+          }
+
+          // result is list or CSV
+          core.info(`Computed tags: "${tags.join(',')}"`);
+          core.exportVariable('DOCKER_TAGS', tags.join(','));
+      env:
+        IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        SHORT_SHA: ${{ steps.gitversion.outputs.shortSha }}
+        FULL_SEMVER: ${{ steps.gitversion.outputs.fullSemVer }}
+        MAJOR: ${{ steps.gitversion.outputs.major }}
+        MINOR: ${{ steps.gitversion.outputs.minor }}
 
     - name: Log into registry
-      if: ${{ (github.ref == 'refs/heads/main') || (!startsWith(github.ref, 'refs/pull')) || startsWith(github.ref, 'refs/tags') }}
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-
-    - name: Push image (latest, ShortSha)
-      if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags') }}
-      run: |
-        docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
-        docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.shortSha}}"
-
-    - name: Push image (NuGetVersionV2)
       if: ${{ !startsWith(github.ref, 'refs/pull') }}
-      run: docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.fullSemVer }}"
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push image (major, minor)
-      if: startsWith(github.ref, 'refs/tags')
-      run: |
-        docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}"
-        docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major }}"
+    - name: Build and push multi-arch image
+      uses: docker/build-push-action@v6
+      with:
+        file: Tingle.AzureCleaner/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: ${{ !startsWith(github.ref, 'refs/pull') }}
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+        cache-to: type=inline # sets BUILDKIT_INLINE_CACHE=1
+        tags: ${{ env.DOCKER_TAGS }}
+        labels: |
+          org.opencontainers.image.source=${{ github.repository }}
+          org.opencontainers.image.version=${{ steps.gitversion.outputs.fullSemVer }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+          com.github.image.run.id=${{ github.run_id }}
+          com.github.image.run.number=${{ github.run_number }}
+          com.github.image.job.id=${{ github.job }}
+          com.github.image.source.sha=${{ github.sha }}
+          com.github.image.source.branch=${{ github.ref }}
 
     - name: Upload Release
       if: startsWith(github.ref, 'refs/tags/')

--- a/Tingle.AzureCleaner/Tingle.AzureCleaner.csproj
+++ b/Tingle.AzureCleaner/Tingle.AzureCleaner.csproj
@@ -56,7 +56,6 @@
     <PackageReference Include="KubernetesClient" Version="16.0.2" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="19.225.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="MiniValidation" Version="0.9.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
@@ -75,6 +74,10 @@
     <PackageReference Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.9" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="0.1.0-beta.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This builds multi-arch images (`linux/amd64` and `linux/arm64`) to allow running the server on a Raspberry Pi and on local macOS machines.

- Use `docker/login-action@v3` for login (better).
- Setup builder using `docker/setup-buildx-action@v3`.
- Build multi-arch images using `docker/build-push-action@v6`.