### PR TITLE
Fix LegacyKeyValueFormat in docker

### DIFF
--- a/Tingle.AzureCleaner/Dockerfile
+++ b/Tingle.AzureCleaner/Dockerfile
@@ -5,7 +5,7 @@ USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
-ENV AS_WEB_APP true
+ENV AS_WEB_APP=true
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS build
 ARG BUILD_CONFIGURATION=Release

--- a/Tingle.AzureCleaner/Dockerfile.CI
+++ b/Tingle.AzureCleaner/Dockerfile.CI
@@ -3,7 +3,7 @@ USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
-ENV AS_WEB_APP true
+ENV AS_WEB_APP=true
 
 COPY . .
 ENTRYPOINT ["dotnet", "Tingle.AzdoCleaner.dll"]


### PR DESCRIPTION
"ENV key=value" should be used instead of legacy "ENV key value" format More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/